### PR TITLE
Publish ci pack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: set-version
+        run: |
+          version=$(egrep -o "version>(.*)</version" install.xml | egrep -o "[0-9.]*")
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Create zip artifact
+        id: zip
+        run: |
+          zip -r LMS-SqueezePlexHub.zip SqueezePlexHub README.md
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LMS-SqueezePlexHub
+          path: LMS-SqueezePlexHub.zip
+
+      - name: Setup Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5'
+
+      - name: Install Perl dependencies
+        run: |
+          cpanm --quiet --notest XML::Simple Digest::SHA
+
+      - name: Update SHA and Version in repo.xml
+        id: tag
+        run: |
+          url="https://github.com/${{ github.repository }}/releases/download/${{ steps.set-version.outputs.version }}"
+          perl repo/release.pl repo/repo.xml ${{ steps.set-version.outputs.version }} LMS-SqueezePlexHub.zip $url
+
+      - name: Commit repo.xml
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: github-actions
+          author_email: github-actions@github.com
+          message: Update repo.xml for release ${{ steps.set-version.outputs.version }}
+          add: repo/repo.xml
+          push: true
+          tag: v${{ steps.set-version.outputs.version }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.set-version.outputs.version }}
+          release_name: Version ${{ steps.set-version.outputs.version }}
+          body: LMS Squeeze Plex Hub Plugin release
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: LMS-SqueezePlexHub.zip
+          asset_name: LMS-SqueezePlexHub.zip
+          asset_content_type: application/zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,19 +39,20 @@ jobs:
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5'
+          perl-version: "5"
 
       - name: Install Perl dependencies
         run: |
-          cpanm --quiet --notest XML::Simple Digest::SHA
+          cpanm --installdeps --notest .
 
       - name: Update SHA and Version in repo.xml
-        id: tag
+        id: update-repo
         run: |
           url="https://github.com/${{ github.repository }}/releases/download/${{ steps.set-version.outputs.version }}"
           perl repo/release.pl repo/repo.xml ${{ steps.set-version.outputs.version }} LMS-SqueezePlexHub.zip $url
 
       - name: Commit repo.xml
+        id: commit-and-tag-repo
         uses: EndBug/add-and-commit@v9
         with:
           author_name: github-actions
@@ -62,8 +63,8 @@ jobs:
           tag: v${{ steps.set-version.outputs.version }}
 
       - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
+        id: create-release
+        uses: comnoco/create-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -74,11 +75,12 @@ jobs:
           prerelease: false
 
       - name: Upload Release Asset
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: LMS-SqueezePlexHub.zip
           asset_name: LMS-SqueezePlexHub.zip
           asset_content_type: application/zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,24 +63,14 @@ jobs:
           tag: v${{ steps.set-version.outputs.version }}
 
       - name: Create GitHub Release
-        id: create-release
-        uses: comnoco/create-release@v2
+        id: create-release-upload-assets
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.set-version.outputs.version }}
-          release_name: Version ${{ steps.set-version.outputs.version }}
-          body: LMS Squeeze Plex Hub Plugin release
+          files: LMS-SqueezePlexHub.zip
+          name: LMS Squeeze Plex Hub Plugin (v${{ steps.set-version.outputs.version }})
+          tag_name: v${{ steps.set-version.outputs.version }}
+          generate_release_notes: true
           draft: false
           prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: LMS-SqueezePlexHub.zip
-          asset_name: LMS-SqueezePlexHub.zip
-          asset_content_type: application/zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Determine version
         id: set-version
         run: |
-          version=$(egrep -o "version>(.*)</version" install.xml | egrep -o "[0-9.]*")
+          version=$(grep -E -o "version>(.*)</version" install.xml | grep -E -o "[0-9.]*")
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Create zip artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,6 @@ jobs:
         run: |
           zip -r LMS-SqueezePlexHub.zip SqueezePlexHub README.md
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: LMS-SqueezePlexHub
-          path: LMS-SqueezePlexHub.zip
-
       - name: Setup Perl
         uses: shogo82148/actions-setup-perl@v1
         with:
@@ -48,7 +42,7 @@ jobs:
       - name: Update SHA and Version in repo.xml
         id: update-repo
         run: |
-          url="https://github.com/${{ github.repository }}/releases/download/${{ steps.set-version.outputs.version }}"
+          url="https://github.com/${{ github.repository }}/releases/download/v${{ steps.set-version.outputs.version }}"
           perl repo/release.pl repo/repo.xml ${{ steps.set-version.outputs.version }} LMS-SqueezePlexHub.zip $url
 
       - name: Commit repo.xml

--- a/SqueezePlexHub/Plugin.pm
+++ b/SqueezePlexHub/Plugin.pm
@@ -24,7 +24,7 @@ sub initPlugin {
 
     $class->SUPER::initPlugin();
 
-    $log->info('LMS Squeeze Plex Hub plugin initialized');
+    $log->info('Squeeze Plex Hub plugin initialized');
     return 1;
 }
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'URI';
 requires 'XML::Simple';
+requires 'Digest::SHA';
 requires 'Devel::Cover';
 requires 'Devel::Cover::Report::Clover';
 

--- a/repo/release.pl
+++ b/repo/release.pl
@@ -5,7 +5,6 @@ use strict;
 use warnings;
 
 use XML::Simple;
-use File::Basename;
 use Digest::SHA;
 
 my $repofile = $ARGV[0];

--- a/repo/release.pl
+++ b/repo/release.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+# Updates a plugin repository XML file with new version, SHA, and URL.
+# Heavily inspired by https://github.com/philippe44/lms-deezer/blob/main/repo/release.pl 🙏
+use strict;
+use warnings;
+
+use XML::Simple;
+use File::Basename;
+use Digest::SHA;
+
+my $repofile = $ARGV[0];
+my $version = $ARGV[1];
+my $zipfile = $ARGV[2];
+my $url = $ARGV[3];
+
+print "Inputs: repo=$repofile version=$version zip=$zipfile url=$url\n";
+
+my $repo = XMLin($repofile, ForceArray => 1, KeepRoot => 0, KeyAttr => 0, NoAttr => 0);
+print "Loaded repo XML from $repofile\n";
+
+$repo->{plugins}[0]->{plugin}[0]->{version} = $version;
+print "Updated plugin version to $version\n";
+
+open (my $fh, "<", $zipfile) or die "Cannot open $zipfile: $!";
+binmode $fh;
+print "Opened zipfile $zipfile for reading\n";
+
+my $digest = Digest::SHA->new;
+$digest->addfile($fh);
+close $fh;
+my $sha = $digest->hexdigest;
+$repo->{plugins}[0]->{plugin}[0]->{sha}[0] = $sha;
+print "Computed SHA: $sha\n";
+
+$url .= "/$zipfile" unless $url =~ m{/$zipfile$};
+$repo->{plugins}[0]->{plugin}[0]->{url}[0] = $url;
+print "Updated plugin URL to $url\n";
+
+XMLout($repo, RootName => 'extensions', NoSort => 1, XMLDecl => 1, KeyAttr => '', OutputFile => $repofile, NoAttr => 0);
+print "Wrote updated repository XML to $repofile\n";

--- a/repo/repo.xml
+++ b/repo/repo.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' standalone='yes'?>
+<extensions>
+    <plugins>
+        <plugin minTarget="8.0" name="Squeeze Plex Hub" version="X.0.0" maxTarget="*">
+            <title lang="EN">Squeeze Plex Hub</title>
+            <category>information</category>
+            <creator>Christian Moser</creator>
+            <desc lang="EN">A Lyrion Music Server plugin that bridges Plex metadata into LMS when tracks are streamed through the Squeeze Plex Hub application.</desc>
+            <sha>xxx</sha>
+            <link>https://github.com/onmomo/lms-squeeze-plex-hub</link>
+            <url>https://github.com/onmomo/lms-squeeze-plex-hub/releases/download/X.0.0/LMS-SqueezePlexHub.zip</url>
+        </plugin>
+    </plugins>
+</extensions>


### PR DESCRIPTION
This pull request introduces a new automated release workflow for the project, making it easier to publish new plugin versions. It adds a GitHub Actions workflow to handle building, packaging, and releasing the plugin, as well as supporting scripts and metadata files for versioning and distribution. There is also a minor log message update for clarity.

**Automated Release Workflow:**

* Added `.github/workflows/publish.yml` to automate building, packaging, versioning, and releasing the plugin using GitHub Actions, including artifact creation, Perl dependency installation, and release asset uploads.

**Release Tooling and Metadata:**

* Introduced `repo/release.pl`, a Perl script to update the plugin repository XML with the new version, SHA, and download URL during the release process.
* Added `repo/repo.xml`, an initial plugin repository XML file containing plugin metadata, version, SHA, and download URL fields required for plugin distribution.

**Minor Improvements:**

* Updated the plugin initialization log message in `SqueezePlexHub/Plugin.pm` for consistency and clarity.