### PR TITLE
update installation instructions / add logo to repo.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,20 @@ While optional, this plugin is strongly recommended when using the [Squeeze Plex
 
 ## Installation
 
+1. Go to LMS server settings -> Manage plugins and search for "**Squeeze Plex Hub**". It should be listed in the 3rd party plugins section.
+2. Activate the plugin and restart.
+3. Use Squeeze Plex Hub to play some tracks, the metadata should be added automatically.
+
+If the plugin is not listed, add the following repository url in the **Additional Repositories** section and follow the installation instructions.
+
+* https://raw.githubusercontent.com/onmomo/lms-squeeze-plex-hub/refs/heads/develop/repo/repo.xml
+
 ### Manual Installation
 
 1. Clone this repository
-2. Ensure the plugin directory is named exactly: SqueezePlexHub
-3. Restart LMS after any change
+2. Mount the SqueezePlexHub directory into $LMS-ROOT-DIR/config/cache/Plugins
+3. Ensure the plugin directory is named exactly: SqueezePlexHub
+4. Restart LMS after any change
    > LMS does **not** hot-reload plugins
 
 ---

--- a/SqueezePlexHub/install.xml
+++ b/SqueezePlexHub/install.xml
@@ -2,7 +2,7 @@
 <extensions>
   <name>PLUGIN_SQUEEZEPLEXHUB</name>
   <description>PLUGIN_SQUEEZEPLEXHUB_DESCRIPTION</description>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <category>information</category>
   <creator>Christian Moser</creator>
   <email></email>

--- a/repo/repo.xml
+++ b/repo/repo.xml
@@ -8,6 +8,7 @@
       <title lang="EN">Squeeze Plex Hub</title>
       <url>https://github.com/onmomo/lms-squeeze-plex-hub/releases/download/v1.0.0/LMS-SqueezePlexHub.zip</url>
       <link>https://github.com/onmomo/lms-squeeze-plex-hub</link>
+      <icon>https://github.com/onmomo/lms-squeeze-plex-hub/blob/develop/SqueezePlexHub/HTML/EN/plugins/SqueezePlexHub/html/images/logo.png?raw=true</icon>
       <sha>de15772281cd4cc197ab430dad2de5a5920a5dcc</sha>
     </plugin>
   </plugins>


### PR DESCRIPTION
This pull request updates the installation instructions and plugin metadata for the Squeeze Plex Hub plugin, making it easier for users to install and providing more complete information in the plugin repository.

Improvements to installation instructions:

* Updated the `README.md` to add step-by-step instructions for installing the plugin via the LMS plugin manager, including what to do if the plugin is not listed, and clarified manual installation steps.

Plugin metadata and repository updates:

* Bumped the plugin version from `1.0.0` to `1.0.1` in `SqueezePlexHub/install.xml`.
* Enhanced the plugin entry in `repo/repo.xml` by adding a project link, icon, and SHA hash for the release, making the plugin listing more informative and verifiable.